### PR TITLE
Fix for Issue #2 - Refactors the `inject_content` function and introduces a mechanism to handle failed injections 

### DIFF
--- a/pelican/plugins/injector/injector.py
+++ b/pelican/plugins/injector/injector.py
@@ -74,11 +74,7 @@ def final_injection_attempt(path, context):
     if not failed_injections:
         return
 
-<<<<<<< HEAD
-    with open(path, "r") as f:
-=======
     with open(path) as f:
->>>>>>> 7f2e2c6 (Static analysis fix. Removing r from open() and adding Return None in inject_content())
         content = f.read()
 
     soup_doc = BeautifulSoup(content, "html.parser")

--- a/pelican/plugins/injector/injector.py
+++ b/pelican/plugins/injector/injector.py
@@ -66,19 +66,20 @@ def page_writer(instance, content):
     if instance.settings.get("INJECTOR_IN_PAGES", False):
         inject_content(content)
 
+
 def final_injection_attempt(path, context):
     """Try to perform injections that failed in inject_content()."""
     failed_injections = context.get("failed_injections", [])
     if not failed_injections:
         return
 
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         content = f.read()
 
     soup_doc = BeautifulSoup(content, "html.parser")
     new_content = perform_injections(soup_doc, failed_injections)
 
-    with open(path, 'w') as f:
+    with open(path, "w") as f:
         f.write(new_content)
 
 

--- a/pelican/plugins/injector/injector.py
+++ b/pelican/plugins/injector/injector.py
@@ -53,6 +53,7 @@ def inject_content(instance):
 
     instance._content = str(soup_doc)
     instance._context["failed_injections"] = failed_injections
+    return None
 
 
 def article_writer(instance, content):
@@ -73,7 +74,11 @@ def final_injection_attempt(path, context):
     if not failed_injections:
         return
 
+<<<<<<< HEAD
     with open(path, "r") as f:
+=======
+    with open(path) as f:
+>>>>>>> 7f2e2c6 (Static analysis fix. Removing r from open() and adding Return None in inject_content())
         content = f.read()
 
     soup_doc = BeautifulSoup(content, "html.parser")


### PR DESCRIPTION
## Summary
This PR refactors the `inject_content` function and introduces a mechanism to handle failed injections in the `injector` plugin.

## Changes
1. **Handling of failed injections**: A new feature has been implemented to handle cases where code injections fail due to the target tags not being found in the content. When an injection fails, it is now added to a list of failed injections that is stored in `instance._context`. A new function, `final_injection_attempt`, was introduced and is connected to the `content_written` signal. This function attempts to perform the failed injections after the content has been written to disk.

### Note
To avoid potential performance issues, it might be interesting to support a new element, potentially with a default value, to support indicating if a certain injection should only be attempted during content_written signal. OTOH, this could be automatic, based on a list of tags that are not found in article/page writes, such as HEAD.
